### PR TITLE
Requires irc, not node-irc

### DIFF
--- a/README
+++ b/README
@@ -1,5 +1,5 @@
 Set up instructions:
- npm install async extend node-irc ripple-lib
+ npm install async extend irc ripple-lib
  cp config-example.js config.js
 
 Customize config.js


### PR DESCRIPTION
Updated README: It seems to require "irc" and not "node-irc."
